### PR TITLE
require("assert") is removed from index.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ node_modules/
 npm-debug.log
 
 #
+# Ide folders.
+#
+.idea/
+
+#
 # OS X.
 #
 

--- a/index.js
+++ b/index.js
@@ -1,17 +1,9 @@
-/**
- * Module dependencies.
- */
+module.exports = function (degrees) {
+    "use strict";
 
-var assert = require('assert');
+    if (typeof degrees !== 'number') {
+        throw new TypeError('Degrees should be a number');
+    }
 
-/**
- * Convert degrees to radians.
- *
- * @param {Number} degrees
- * @return {Number}
- */
-
-module.exports = function(degrees) {
-  assert('number' == typeof degrees, 'Degrees should be a number');
-  return degrees * (Math.PI / 180);
-}
+    return degrees * (Math.PI / 180);
+};

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "degrees-radians",
-  "version": "1.0.3",
+  "name": "@yavuzmester/degrees-radians",
+  "version": "1.0.4",
   "description": "Convert degrees to radians",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test ./node_modules/mocha/bin/mocha --recursive --harmony-generators -R spec",
+    "test": "mocha",
     "coverage": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha --report text --recursive -- -R spec && rm -rf ./coverage/"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoshuawuyts/degrees-radians"
+    "url": "https://github.com/yavuzmester/degrees-radians"
   },
   "keywords": [],
-  "author": "Yoshua Wuyts <i@yoshuawuyts.com>",
+  "author": "Yavuz Mester",
   "license": "MIT",
   "devDependencies": {
     "coveralls": "^2.10.0",


### PR DESCRIPTION
When browserified assert also comes in to the bundle as it is required in index.js. It is not desirable to me.

I removed the require("assert") line and replace the assert call with throw new TypeError.